### PR TITLE
Add Microsoft Graph cloud mode for OneDrive storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Install the required packages:
 pip install -r requirements.txt
 ```
 
-> **Note:** The project ships with a local OneDrive mock. To connect to a real tenant, populate the environment variables described in `config/settings.py` and implement the Microsoft Graph upload/download requests inside the cloud modules.
+> **Note:** The project ships with a local OneDrive mock by default. Set `ONEDRIVE_STORAGE_MODE=cloud` (and provide valid Microsoft Graph admin credentials) to push uploads directly into your tenant. The connector now handles folder provisioning, file uploads, and downloads through the Graph API while keeping a synchronized local cache for metadata.
 
 ## Usage
 
@@ -69,6 +69,7 @@ Environment variables:
 - `ADMIN_CLIENT_ID`
 - `ADMIN_TENANT_ID`
 - `ADMIN_REDIRECT_URI`
+- `ONEDRIVE_STORAGE_MODE` ("local" or "cloud")
 - `ONEDRIVE_ROOT_FOLDER`
 - `METADATA_FILE_NAME`
 - `USER_ACTIVITY_FILE_NAME`

--- a/config/settings.py
+++ b/config/settings.py
@@ -24,6 +24,7 @@ class AppConfig:
     admin_client_id: str
     admin_tenant_id: str
     admin_redirect_uri: str
+    onedrive_storage_mode: str
     onedrive_root_folder: str
     metadata_file_name: str
     user_activity_file_name: str
@@ -60,6 +61,7 @@ def load_app_config() -> AppConfig:
             "ADMIN_REDIRECT_URI",
             admin_auth_defaults.get("redirect_uri", "http://localhost:8080"),
         ),
+        onedrive_storage_mode=os.getenv("ONEDRIVE_STORAGE_MODE", "local"),
         onedrive_root_folder=os.getenv("ONEDRIVE_ROOT_FOLDER", "IndustrialDataSystem"),
         metadata_file_name=os.getenv("METADATA_FILE_NAME", "upload_metadata.xlsx"),
         user_activity_file_name=os.getenv("USER_ACTIVITY_FILE_NAME", "user_activity_log.xlsx"),

--- a/src/cloud/admin_onedrive_connector.py
+++ b/src/cloud/admin_onedrive_connector.py
@@ -2,8 +2,11 @@
 from __future__ import annotations
 
 import logging
-from pathlib import Path
+import shutil
+from pathlib import Path, PurePath, PurePosixPath
 from typing import Optional
+
+import requests
 
 from config.settings import DATA_DIR, load_app_config
 from src.auth.admin_onedrive_auth import AdminOneDriveAuth
@@ -13,14 +16,37 @@ logger = logging.getLogger(__name__)
 
 
 class AdminOneDriveConnector:
-    """Simplified connector storing files locally while mimicking OneDrive structure."""
+    """Connector that supports both local mock and real OneDrive storage."""
+
+    GRAPH_BASE_URL = "https://graph.microsoft.com/v1.0"
+    GRAPH_TIMEOUT = 30
 
     def __init__(self) -> None:
         self.config = load_app_config()
         self.auth = AdminOneDriveAuth()
-        self.root = DATA_DIR / "mock_onedrive" / self.config.onedrive_root_folder
-        ensure_directory(self.root)
+        self.mode = (self.config.onedrive_storage_mode or "local").strip().lower()
+        if self.mode not in {"local", "cloud"}:
+            logger.warning(
+                "Unknown ONEDRIVE_STORAGE_MODE '%s'; falling back to local mode.",
+                self.mode,
+            )
+            self.mode = "local"
+
+        self.cache_root = DATA_DIR / "mock_onedrive" / self.config.onedrive_root_folder
+        ensure_directory(self.cache_root)
+
+        if self.is_cloud_mode:
+            root_folder = (self.config.onedrive_root_folder or "IndustrialDataSystem").strip("/")
+            self.drive_root: PurePath = PurePosixPath(root_folder) if root_folder else PurePosixPath("")
+        else:
+            self.drive_root = self.cache_root
+
+        self.session = requests.Session()
         self._token: Optional[str] = None
+
+    @property
+    def is_cloud_mode(self) -> bool:
+        return self.mode == "cloud"
 
     def ensure_authenticated(self) -> Optional[str]:
         if self._token:
@@ -29,10 +55,196 @@ class AdminOneDriveConnector:
         if token:
             logger.info("Admin authenticated successfully.")
             self._token = token
+        elif self.is_cloud_mode:
+            logger.error("Cloud mode requested but authentication failed.")
         else:
             logger.warning("Running in offline mode without OneDrive token.")
         return self._token
 
     def base_path(self) -> Path:
-        ensure_directory(self.root)
-        return self.root
+        """Return the local cache base path used for metadata and offline storage."""
+
+        ensure_directory(self.cache_root)
+        return self.cache_root
+
+    def drive_base_path(self) -> PurePath:
+        """Return the logical root of the OneDrive structure."""
+
+        return self.drive_root
+
+    # ------------------------------------------------------------------
+    # Folder helpers
+    # ------------------------------------------------------------------
+    def ensure_user_structure(self, user_id: str) -> dict[str, PurePath]:
+        base = self.drive_base_path()
+        user_root = base / "Users" / user_id
+        folders: dict[str, PurePath] = {
+            "root": user_root,
+            "csv": user_root / "CSV",
+            "images": user_root / "Images",
+            "excel": user_root / "Excel",
+            "logs": user_root / "Logs",
+        }
+
+        if self.is_cloud_mode:
+            for folder in folders.values():
+                self._ensure_remote_folder(folder)
+        else:
+            for folder in folders.values():
+                ensure_directory(Path(folder))
+
+        return folders
+
+    def metadata_path(self) -> Path:
+        return self.base_path() / "Metadata"
+
+    def templates_path(self) -> Path:
+        return self.base_path() / "Templates"
+
+    # ------------------------------------------------------------------
+    # Upload/download helpers for cloud mode
+    # ------------------------------------------------------------------
+    def upload_to_drive(
+        self,
+        target_path: PurePath,
+        *,
+        local_path: Path | None = None,
+        data: bytes | None = None,
+    ) -> dict:
+        """Upload file bytes to the configured storage location."""
+
+        if not self.is_cloud_mode:
+            destination = Path(target_path)
+            ensure_directory(destination.parent)
+            if data is not None:
+                destination.write_bytes(data)
+            elif local_path is not None:
+                shutil.copy2(local_path, destination)
+            else:
+                raise ValueError("Either local_path or data must be provided for upload.")
+            return {"size": destination.stat().st_size, "local_path": str(destination)}
+
+        if data is None:
+            if local_path is None:
+                raise ValueError("Either local_path or data must be provided for upload.")
+            data = local_path.read_bytes()
+
+        self._ensure_remote_folder(target_path.parent)
+        response = self.session.put(
+            self._drive_content_url(target_path),
+            headers=self._graph_headers(content_type="application/octet-stream"),
+            data=data,
+            timeout=self.GRAPH_TIMEOUT,
+        )
+        response.raise_for_status()
+        result = response.json()
+        cache_path = self._write_cache(target_path, data)
+        result["local_cache_path"] = str(cache_path)
+        return result
+
+    def download_to_cache(self, target_path: PurePath) -> Optional[Path]:
+        if not self.is_cloud_mode:
+            local_path = Path(target_path)
+            return local_path if local_path.exists() else None
+
+        cache_path = self._cache_path_for(target_path)
+        if cache_path.exists():
+            return cache_path
+
+        response = self.session.get(
+            self._drive_content_url(target_path),
+            headers=self._graph_headers(),
+            timeout=self.GRAPH_TIMEOUT,
+        )
+        if response.status_code == 404:
+            return None
+        response.raise_for_status()
+        ensure_directory(cache_path.parent)
+        cache_path.write_bytes(response.content)
+        return cache_path
+
+    def drive_relative_string(self, path: PurePath) -> str:
+        return self.relative_to_drive_root(path).as_posix()
+
+    def relative_to_drive_root(self, path: PurePath) -> PurePosixPath:
+        base = self.drive_base_path()
+        try:
+            relative = path.relative_to(base)
+        except ValueError:
+            relative = path
+        return PurePosixPath(relative.as_posix())
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _drive_path_str(self, path: PurePath) -> str:
+        return path.as_posix().lstrip("/")
+
+    def _drive_item_url(self, path: PurePath) -> str:
+        relative = self._drive_path_str(path)
+        if relative:
+            return f"{self.GRAPH_BASE_URL}/me/drive/root:/{relative}:"
+        return f"{self.GRAPH_BASE_URL}/me/drive/root"
+
+    def _drive_content_url(self, path: PurePath) -> str:
+        relative = self._drive_path_str(path)
+        if relative:
+            return f"{self.GRAPH_BASE_URL}/me/drive/root:/{relative}:/content"
+        return f"{self.GRAPH_BASE_URL}/me/drive/root/content"
+
+    def _graph_headers(self, content_type: str | None = None) -> dict[str, str]:
+        token = self.ensure_authenticated()
+        if not token:
+            raise RuntimeError("OneDrive authentication failed; cannot perform cloud operation.")
+        headers = {"Authorization": f"Bearer {token}"}
+        if content_type:
+            headers["Content-Type"] = content_type
+        return headers
+
+    def _ensure_remote_folder(self, folder: PurePath) -> None:
+        if not self.is_cloud_mode:
+            return
+        if str(folder) in {".", ""}:
+            return
+        # Ensure parent first
+        parent = folder.parent
+        if parent != folder:
+            self._ensure_remote_folder(parent)
+
+        response = self.session.get(
+            self._drive_item_url(folder),
+            headers=self._graph_headers(),
+            timeout=self.GRAPH_TIMEOUT,
+        )
+        if response.status_code == 200:
+            return
+        if response.status_code != 404:
+            response.raise_for_status()
+
+        parent_url = (
+            f"{self.GRAPH_BASE_URL}/me/drive/root/children"
+            if folder.parent == folder or str(folder.parent) in {".", ""}
+            else f"{self.GRAPH_BASE_URL}/me/drive/root:/{self._drive_path_str(folder.parent)}:/children"
+        )
+        create_response = self.session.post(
+            parent_url,
+            headers=self._graph_headers(content_type="application/json"),
+            json={
+                "name": folder.name,
+                "folder": {},
+                "@microsoft.graph.conflictBehavior": "replace",
+            },
+            timeout=self.GRAPH_TIMEOUT,
+        )
+        if create_response.status_code not in {200, 201}:
+            create_response.raise_for_status()
+
+    def _cache_path_for(self, path: PurePath) -> Path:
+        relative = self.relative_to_drive_root(path)
+        return self.base_path() / Path(relative.as_posix())
+
+    def _write_cache(self, path: PurePath, data: bytes) -> Path:
+        cache_path = self._cache_path_for(path)
+        ensure_directory(cache_path.parent)
+        cache_path.write_bytes(data)
+        return cache_path

--- a/src/cloud/folder_manager.py
+++ b/src/cloud/folder_manager.py
@@ -1,25 +1,21 @@
 """Folder management utilities for OneDrive structure."""
 from __future__ import annotations
 
-from pathlib import Path
+from pathlib import Path, PurePath
 from typing import Dict
 
 from src.cloud.admin_onedrive_connector import AdminOneDriveConnector
-from src.utils.helpers import build_user_structure
 
 
 class FolderManager:
     def __init__(self, connector: AdminOneDriveConnector | None = None) -> None:
         self.connector = connector or AdminOneDriveConnector()
 
-    def ensure_user_folders(self, user_id: str) -> Dict[str, Path]:
-        base = self.connector.base_path()
-        return build_user_structure(base, user_id)
+    def ensure_user_folders(self, user_id: str) -> Dict[str, PurePath]:
+        return self.connector.ensure_user_structure(user_id)
 
     def metadata_folder(self) -> Path:
-        base = self.connector.base_path()
-        return base / "Metadata"
+        return self.connector.metadata_path()
 
     def templates_folder(self) -> Path:
-        base = self.connector.base_path()
-        return base / "Templates"
+        return self.connector.templates_path()

--- a/src/cloud/onedrive_downloader.py
+++ b/src/cloud/onedrive_downloader.py
@@ -13,7 +13,11 @@ class OneDriveDownloader:
 
     def download_excel(self, user_id: str, filename: str) -> Optional[Path]:
         folders = self.manager.ensure_user_folders(user_id)
-        path = folders["excel"] / filename
-        if path.exists():
-            return path
-        return None
+        target = folders["excel"] / filename
+        connector = self.manager.connector
+
+        if connector.is_cloud_mode:
+            return connector.download_to_cache(target)
+
+        local_path = Path(target)
+        return local_path if local_path.exists() else None

--- a/src/cloud/onedrive_uploader.py
+++ b/src/cloud/onedrive_uploader.py
@@ -1,9 +1,8 @@
-"""Handles uploading files to the admin OneDrive (local mock)."""
+"""Handles uploading files to OneDrive storage."""
 from __future__ import annotations
 
 import shutil
 from pathlib import Path
-from typing import Optional
 
 from src.cloud.folder_manager import FolderManager
 from src.utils.file_validator import validate_file_type
@@ -22,8 +21,26 @@ class OneDriveUploader:
             "Image": folders["images"],
             "Excel": folders["excel"],
         }[file_type]
-        target_dir.mkdir(parents=True, exist_ok=True)
-        destination = target_dir / local_path.name
+        connector = self.manager.connector
+
+        if connector.is_cloud_mode:
+            destination = target_dir / local_path.name
+            upload_result = connector.upload_to_drive(destination, local_path=local_path)
+            size_bytes = upload_result.get("size", local_path.stat().st_size)
+            return {
+                "user_id": user_id,
+                "file_type": file_type,
+                "file_name": local_path.name,
+                "size_kb": round(size_bytes / 1024.0, 2),
+                "uploaded_at": timestamp_now(),
+                "onedrive_path": connector.drive_relative_string(destination),
+                "onedrive_url": upload_result.get("webUrl", ""),
+                "notes": notes,
+            }
+
+        target_path = Path(target_dir)
+        target_path.mkdir(parents=True, exist_ok=True)
+        destination = target_path / local_path.name
         shutil.copy2(local_path, destination)
         return {
             "user_id": user_id,
@@ -31,19 +48,38 @@ class OneDriveUploader:
             "file_name": local_path.name,
             "size_kb": round(destination.stat().st_size / 1024.0, 2),
             "uploaded_at": timestamp_now(),
-            "onedrive_path": str(destination.relative_to(self.manager.connector.base_path())),
+            "onedrive_path": str(destination.relative_to(connector.base_path())),
+            "onedrive_url": "",
             "notes": notes,
         }
 
     def upload_bytes(self, user_id: str, filename: str, content: bytes) -> dict:
         folders = self.manager.ensure_user_folders(user_id)
         destination = folders["excel"] / filename
-        destination.write_bytes(content)
+        connector = self.manager.connector
+
+        if connector.is_cloud_mode:
+            upload_result = connector.upload_to_drive(destination, data=content)
+            size_bytes = upload_result.get("size", len(content))
+            return {
+                "user_id": user_id,
+                "file_type": "Excel",
+                "file_name": filename,
+                "size_kb": round(size_bytes / 1024.0, 2),
+                "uploaded_at": timestamp_now(),
+                "onedrive_path": connector.drive_relative_string(destination),
+                "onedrive_url": upload_result.get("webUrl", ""),
+            }
+
+        target_path = Path(destination)
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        target_path.write_bytes(content)
         return {
             "user_id": user_id,
             "file_type": "Excel",
             "file_name": filename,
             "size_kb": round(len(content) / 1024.0, 2),
             "uploaded_at": timestamp_now(),
-            "onedrive_path": str(destination.relative_to(self.manager.connector.base_path())),
+            "onedrive_path": str(target_path.relative_to(connector.base_path())),
+            "onedrive_url": "",
         }

--- a/src/gui/upload_panel.py
+++ b/src/gui/upload_panel.py
@@ -43,6 +43,7 @@ class UploadPanel(ttk.Frame):
                 "File_Size_KB": record["size_kb"],
                 "Creation_Method": "Direct_Upload",
                 "OneDrive_Path": record["onedrive_path"],
+                "OneDrive_URL": record.get("onedrive_url", ""),
                 "Status": "Success",
             }
             self.metadata_handler.append_entry(metadata)

--- a/src/utils/helpers.py
+++ b/src/utils/helpers.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from datetime import datetime
 from pathlib import Path
-from typing import Dict
 
 
 def timestamp_now() -> str:
@@ -12,17 +11,3 @@ def timestamp_now() -> str:
 
 def ensure_directory(path: Path) -> None:
     path.mkdir(parents=True, exist_ok=True)
-
-
-def build_user_structure(base: Path, user_id: str) -> Dict[str, Path]:
-    user_root = base / "Users" / user_id
-    folders = {
-        "root": user_root,
-        "csv": user_root / "CSV",
-        "images": user_root / "Images",
-        "excel": user_root / "Excel",
-        "logs": user_root / "Logs",
-    }
-    for folder in folders.values():
-        ensure_directory(folder)
-    return folders


### PR DESCRIPTION
## Summary
- add a configurable ONEDRIVE_STORAGE_MODE to switch between local mock storage and live OneDrive
- implement Microsoft Graph folder provisioning, uploads, downloads, and caching in the admin connector
- update upload flows, metadata recording, and documentation to surface remote OneDrive URLs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e51ac62b688322b1cb3bbed3a04774