### PR TITLE
Add admin-gated PyQt desktop app with OneDrive CSV uploads

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,10 @@
+# Rename this file to .env and populate with your Azure application secrets.
+CLIENT_ID=your-client-id
+TENANT_ID=your-tenant-id
+CLIENT_SECRET=your-client-secret
+# Optional: bootstrap an initial admin user.
+ADMIN_USERNAME=admin
+ADMIN_PASSWORD=change-me
+ADMIN_EMAIL=admin@example.com
+# Optional: override the app folder used for OneDrive uploads.
+ONEDRIVE_APP_FOLDER=IndustrialDataSystem

--- a/README.md
+++ b/README.md
@@ -1,0 +1,89 @@
+# Industrial Data System Desktop Application
+
+A PyQt5 desktop application featuring admin-approved authentication, CSV previewing, and automatic uploads to OneDrive via Microsoft Graph.
+
+## Features
+
+- Login and registration workflow with admin approval.
+- Admin panel for reviewing, approving, or rejecting pending accounts.
+- CSV viewer with upload button and drag-and-drop support.
+- OneDrive integration that stores uploads in user-specific folders under the configured app directory.
+- Password hashing using bcrypt and environment-based configuration for secrets.
+
+## Project Structure
+
+```
+project/
+├── auth.py
+├── database.py
+├── main.py
+├── onedrive_auth.py
+├── onedrive_upload.py
+├── requirements.txt
+├── README.md
+└── .env               # provide your own values before running
+```
+
+## Prerequisites
+
+- Python 3.10+
+- Azure AD application with `Files.ReadWrite`, `Files.ReadWrite.AppFolder`, `User.Read`, and `offline_access` permissions and admin consent granted.
+
+## Installation
+
+1. (Optional) create and activate a virtual environment.
+2. Install dependencies:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+3. Copy `.env` and populate the values:
+
+   ```bash
+   cp .env .env.local
+   # Edit .env.local and fill in CLIENT_ID, TENANT_ID, CLIENT_SECRET, etc.
+   ```
+
+   Set the `CLIENT_ID`, `TENANT_ID`, and `CLIENT_SECRET` from your Azure application.
+   Optionally set `ADMIN_USERNAME`, `ADMIN_PASSWORD`, and `ADMIN_EMAIL` to bootstrap an approved admin on startup.
+
+4. Export `IDS_DB_PATH` if you want to override the default SQLite database location (defaults to `app.db`).
+
+## Usage
+
+1. Run the application:
+
+   ```bash
+   python main.py
+   ```
+
+2. Register a new user. The registration will be stored as `pending` until an admin approves it.
+3. Log in as an admin (use the bootstrapped credentials or manually insert a user into the database) and open the admin panel to approve or reject users.
+4. Once approved, a user can log in to access the main interface:
+   - **Upload CSV** button in the top-left corner opens a file dialog.
+   - **Drag-and-drop box** in the bottom-right corner accepts `.csv` files.
+   - The center table displays the CSV contents.
+   - Uploads are automatically sent to OneDrive at `Apps/<ONEDRIVE_APP_FOLDER>/Users/<username>/`.
+
+## Packaging
+
+To build a standalone executable with PyInstaller:
+
+```bash
+pyinstaller --onefile --noconsole main.py
+```
+
+The resulting binary will be placed in the `dist/` directory.
+
+## Troubleshooting
+
+- **Missing configuration** – ensure `.env.local` (or `.env`) is present with valid Azure credentials before running the app.
+- **Token acquisition errors** – confirm the Azure AD application has the required permissions and the secrets are correct.
+- **OneDrive upload failures** – check network connectivity and that the signed-in application has access to the OneDrive account used for uploads.
+
+## Security Notes
+
+- Secrets should never be committed to source control. Use a local `.env` or environment variables.
+- Passwords are hashed using bcrypt before being stored in SQLite.
+- Delete or protect the SQLite database (`app.db`) if sensitive data is stored locally.

--- a/auth.py
+++ b/auth.py
@@ -1,0 +1,109 @@
+"""Authentication helpers for the Industrial Data System application."""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import List
+
+import bcrypt
+
+from database import (
+    add_user,
+    ensure_admin_user,
+    get_pending_users,
+    get_user_by_username,
+    update_user_status,
+)
+
+
+class AuthError(Exception):
+    """Base class for authentication errors."""
+
+
+class RegistrationError(AuthError):
+    """Raised when a registration attempt fails."""
+
+
+class LoginError(AuthError):
+    """Raised when login fails."""
+
+
+@dataclass
+class User:
+    username: str
+    email: str
+    role: str
+    status: str
+
+
+def hash_password(password: str) -> str:
+    if not password:
+        raise ValueError("Password must not be empty")
+    return bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
+
+
+def verify_password(password: str, password_hash: str) -> bool:
+    return bcrypt.checkpw(password.encode("utf-8"), password_hash.encode("utf-8"))
+
+
+def normalize_username(username: str) -> str:
+    username = username.strip().lower()
+    if not username:
+        raise RegistrationError("Username cannot be empty")
+    return username
+
+
+def register_user(username: str, email: str, password: str) -> None:
+    username = normalize_username(username)
+    email = email.strip()
+    if not email:
+        raise RegistrationError("Email cannot be empty")
+    if get_user_by_username(username):
+        raise RegistrationError("Username already exists")
+    password_hash = hash_password(password)
+    add_user(username=username, email=email, password_hash=password_hash)
+
+
+def authenticate_user(username: str, password: str) -> User:
+    username = normalize_username(username)
+    record = get_user_by_username(username)
+    if not record:
+        raise LoginError("Invalid username or password")
+    if not verify_password(password, record["password_hash"]):
+        raise LoginError("Invalid username or password")
+    return User(
+        username=record["username"],
+        email=record["email"],
+        role=record["role"],
+        status=record["status"],
+    )
+
+
+def list_pending_users() -> List[User]:
+    return [
+        User(username=row["username"], email=row["email"], role=row["role"], status=row["status"])
+        for row in get_pending_users()
+    ]
+
+
+def approve_user(username: str) -> None:
+    update_user_status(normalize_username(username), "approved")
+
+
+def reject_user(username: str) -> None:
+    update_user_status(normalize_username(username), "rejected")
+
+
+def bootstrap_default_admin() -> None:
+    """Create an admin user from environment variables if configured."""
+    admin_username = os.getenv("ADMIN_USERNAME")
+    admin_password = os.getenv("ADMIN_PASSWORD")
+    admin_email = os.getenv("ADMIN_EMAIL", "admin@example.com")
+
+    if admin_username and admin_password:
+        hashed = hash_password(admin_password)
+        ensure_admin_user(admin_username, hashed, email=admin_email)
+
+
+# Automatically bootstrap an admin if environment variables are provided.
+bootstrap_default_admin()

--- a/database.py
+++ b/database.py
@@ -1,0 +1,107 @@
+"""Database utilities for the Industrial Data System application."""
+from __future__ import annotations
+
+import os
+import sqlite3
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Generator, Iterable, Optional
+
+DEFAULT_DB_PATH = Path(os.getenv("IDS_DB_PATH", "app.db"))
+
+
+def _ensure_directory(path: Path) -> None:
+    if not path.parent.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+
+@contextmanager
+def get_connection(db_path: Path = DEFAULT_DB_PATH) -> Generator[sqlite3.Connection, None, None]:
+    """Context manager returning a SQLite connection with row factory enabled."""
+    _ensure_directory(db_path)
+    connection = sqlite3.connect(db_path)
+    connection.row_factory = sqlite3.Row
+    try:
+        yield connection
+    finally:
+        connection.commit()
+        connection.close()
+
+
+def initialize_database(db_path: Path = DEFAULT_DB_PATH) -> None:
+    """Create the users table if it does not already exist."""
+    with get_connection(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS users (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                username TEXT UNIQUE NOT NULL,
+                email TEXT UNIQUE NOT NULL,
+                password_hash TEXT NOT NULL,
+                role TEXT NOT NULL DEFAULT 'user',
+                status TEXT NOT NULL DEFAULT 'pending'
+            )
+            """
+        )
+
+
+def add_user(username: str, email: str, password_hash: str, role: str = "user", *, db_path: Path = DEFAULT_DB_PATH) -> None:
+    """Insert a new user into the database."""
+    with get_connection(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO users (username, email, password_hash, role, status)
+            VALUES (?, ?, ?, ?, 'pending')
+            """,
+            (username.lower(), email, password_hash, role),
+        )
+
+
+def get_user_by_username(username: str, *, db_path: Path = DEFAULT_DB_PATH) -> Optional[sqlite3.Row]:
+    """Return a user row by username if it exists."""
+    with get_connection(db_path) as conn:
+        cursor = conn.execute("SELECT * FROM users WHERE username = ?", (username.lower(),))
+        return cursor.fetchone()
+
+
+def get_pending_users(*, db_path: Path = DEFAULT_DB_PATH) -> Iterable[sqlite3.Row]:
+    """Return an iterable of pending user registrations."""
+    with get_connection(db_path) as conn:
+        cursor = conn.execute("SELECT * FROM users WHERE status = 'pending' ORDER BY username ASC")
+        return cursor.fetchall()
+
+
+def update_user_status(username: str, status: str, *, db_path: Path = DEFAULT_DB_PATH) -> None:
+    """Update the status of a user (pending/approved/rejected)."""
+    with get_connection(db_path) as conn:
+        conn.execute("UPDATE users SET status = ? WHERE username = ?", (status, username.lower()))
+
+
+def set_user_role(username: str, role: str, *, db_path: Path = DEFAULT_DB_PATH) -> None:
+    """Change a user's role."""
+    with get_connection(db_path) as conn:
+        conn.execute("UPDATE users SET role = ? WHERE username = ?", (role, username.lower()))
+
+
+def ensure_admin_user(username: str, password_hash: str, email: str = "admin@example.com", *, db_path: Path = DEFAULT_DB_PATH) -> None:
+    """Ensure that an admin user exists with the provided credentials.
+
+    If the username already exists, its role is promoted to admin but the password is left unchanged.
+    """
+    with get_connection(db_path) as conn:
+        cursor = conn.execute("SELECT id FROM users WHERE username = ?", (username.lower(),))
+        existing = cursor.fetchone()
+        if existing:
+            conn.execute("UPDATE users SET role = 'admin', status = 'approved' WHERE username = ?", (username.lower(),))
+        else:
+            conn.execute(
+                """
+                INSERT INTO users (username, email, password_hash, role, status)
+                VALUES (?, ?, ?, 'admin', 'approved')
+                """,
+                (username.lower(), email, password_hash),
+            )
+
+
+# Initialize database when the module is imported.
+initialize_database()

--- a/main.py
+++ b/main.py
@@ -1,0 +1,373 @@
+"""PyQt5 application providing authentication, CSV preview, and OneDrive uploads."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pandas as pd
+from PyQt5 import QtCore, QtGui, QtWidgets
+
+from auth import (
+    LoginError,
+    RegistrationError,
+    approve_user,
+    authenticate_user,
+    list_pending_users,
+    register_user,
+    reject_user,
+    User,
+)
+from onedrive_upload import upload_file_to_onedrive
+
+
+class DropArea(QtWidgets.QLabel):
+    """Widget that accepts dragged CSV files."""
+
+    fileDropped = QtCore.pyqtSignal(str)
+
+    def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setAcceptDrops(True)
+        self.setAlignment(QtCore.Qt.AlignCenter)
+        self.setText("Drop CSV Here")
+        self.setStyleSheet(
+            """
+            QLabel {
+                border: 2px dashed #2980b9;
+                border-radius: 6px;
+                padding: 16px;
+                background-color: #ecf6fd;
+                color: #2980b9;
+                font-weight: bold;
+            }
+            """
+        )
+        self.setMinimumSize(200, 120)
+
+    def dragEnterEvent(self, event: QtGui.QDragEnterEvent) -> None:  # type: ignore[override]
+        if event.mimeData().hasUrls() and any(url.toLocalFile().lower().endswith(".csv") for url in event.mimeData().urls()):
+            event.acceptProposedAction()
+        else:
+            event.ignore()
+
+    def dropEvent(self, event: QtGui.QDropEvent) -> None:  # type: ignore[override]
+        for url in event.mimeData().urls():
+            path = url.toLocalFile()
+            if path.lower().endswith(".csv"):
+                self.fileDropped.emit(path)
+                break
+        event.acceptProposedAction()
+
+
+class CsvViewer(QtWidgets.QTableWidget):
+    """Simple table widget to display pandas DataFrames."""
+
+    def load_dataframe(self, frame: pd.DataFrame) -> None:
+        self.clear()
+        self.setRowCount(len(frame.index))
+        self.setColumnCount(len(frame.columns))
+        self.setHorizontalHeaderLabels([str(column) for column in frame.columns])
+        for row_index, (_, row) in enumerate(frame.iterrows()):
+            for column_index, value in enumerate(row):
+                item = QtWidgets.QTableWidgetItem(str(value))
+                self.setItem(row_index, column_index, item)
+        self.resizeColumnsToContents()
+        self.resizeRowsToContents()
+
+
+class MainWindow(QtWidgets.QMainWindow):
+    """Main application window for approved end users."""
+
+    def __init__(self, user: User) -> None:
+        super().__init__()
+        self.user = user
+        self.setWindowTitle(f"Industrial Data System - {user.username}")
+        self.resize(900, 600)
+
+        central = QtWidgets.QWidget()
+        layout = QtWidgets.QGridLayout(central)
+        layout.setContentsMargins(12, 12, 12, 12)
+        layout.setSpacing(12)
+
+        self.upload_button = QtWidgets.QPushButton("Upload CSV")
+        self.upload_button.clicked.connect(self.open_file_dialog)
+
+        self.viewer = CsvViewer()
+
+        self.drop_area = DropArea()
+        self.drop_area.fileDropped.connect(self.process_file)
+
+        layout.addWidget(self.upload_button, 0, 0, alignment=QtCore.Qt.AlignLeft | QtCore.Qt.AlignTop)
+        layout.addWidget(self.viewer, 1, 0, 1, 2)
+        layout.addWidget(self.drop_area, 2, 1, alignment=QtCore.Qt.AlignRight | QtCore.Qt.AlignBottom)
+
+        layout.setRowStretch(1, 1)
+        layout.setColumnStretch(0, 1)
+        layout.setColumnStretch(1, 1)
+
+        self.setCentralWidget(central)
+
+    def open_file_dialog(self) -> None:
+        file_path, _ = QtWidgets.QFileDialog.getOpenFileName(
+            self, "Select CSV", str(Path.home()), "CSV Files (*.csv)"
+        )
+        if file_path:
+            self.process_file(file_path)
+
+    def process_file(self, path: str) -> None:
+        try:
+            dataframe = pd.read_csv(path)
+        except Exception as exc:  # pragma: no cover - GUI feedback path
+            QtWidgets.QMessageBox.critical(self, "CSV Error", f"Failed to read CSV file:\n{exc}")
+            return
+
+        self.viewer.load_dataframe(dataframe)
+
+        try:
+            upload_file_to_onedrive(path, self.user.username)
+        except Exception as exc:  # pragma: no cover - GUI feedback path
+            QtWidgets.QMessageBox.critical(self, "Upload Failed", str(exc))
+            return
+
+        QtWidgets.QMessageBox.information(
+            self,
+            "Upload Complete",
+            f"{Path(path).name} uploaded to OneDrive successfully.",
+        )
+
+
+class LoginWidget(QtWidgets.QWidget):
+    loginRequested = QtCore.pyqtSignal(str, str)
+    showRegister = QtCore.pyqtSignal()
+
+    def __init__(self) -> None:
+        super().__init__()
+        layout = QtWidgets.QVBoxLayout(self)
+
+        title = QtWidgets.QLabel("Login")
+        title.setAlignment(QtCore.Qt.AlignCenter)
+        title.setStyleSheet("font-size: 20px; font-weight: bold;")
+
+        self.username_input = QtWidgets.QLineEdit()
+        self.username_input.setPlaceholderText("Username")
+
+        self.password_input = QtWidgets.QLineEdit()
+        self.password_input.setPlaceholderText("Password")
+        self.password_input.setEchoMode(QtWidgets.QLineEdit.Password)
+
+        login_button = QtWidgets.QPushButton("Login")
+        login_button.clicked.connect(self._emit_login)
+
+        register_link = QtWidgets.QPushButton("Register")
+        register_link.setFlat(True)
+        register_link.clicked.connect(self.showRegister.emit)
+
+        layout.addWidget(title)
+        layout.addSpacing(12)
+        layout.addWidget(self.username_input)
+        layout.addWidget(self.password_input)
+        layout.addWidget(login_button)
+        layout.addSpacing(6)
+        layout.addWidget(register_link)
+        layout.addStretch(1)
+
+    def _emit_login(self) -> None:
+        self.loginRequested.emit(self.username_input.text(), self.password_input.text())
+
+
+class RegisterWidget(QtWidgets.QWidget):
+    registerRequested = QtCore.pyqtSignal(str, str, str)
+    showLogin = QtCore.pyqtSignal()
+
+    def __init__(self) -> None:
+        super().__init__()
+        layout = QtWidgets.QVBoxLayout(self)
+
+        title = QtWidgets.QLabel("Register")
+        title.setAlignment(QtCore.Qt.AlignCenter)
+        title.setStyleSheet("font-size: 20px; font-weight: bold;")
+
+        self.username_input = QtWidgets.QLineEdit()
+        self.username_input.setPlaceholderText("Username")
+
+        self.email_input = QtWidgets.QLineEdit()
+        self.email_input.setPlaceholderText("Email")
+
+        self.password_input = QtWidgets.QLineEdit()
+        self.password_input.setPlaceholderText("Password")
+        self.password_input.setEchoMode(QtWidgets.QLineEdit.Password)
+
+        register_button = QtWidgets.QPushButton("Submit Registration")
+        register_button.clicked.connect(self._emit_register)
+
+        login_link = QtWidgets.QPushButton("Back to Login")
+        login_link.setFlat(True)
+        login_link.clicked.connect(self.showLogin.emit)
+
+        layout.addWidget(title)
+        layout.addSpacing(12)
+        layout.addWidget(self.username_input)
+        layout.addWidget(self.email_input)
+        layout.addWidget(self.password_input)
+        layout.addWidget(register_button)
+        layout.addSpacing(6)
+        layout.addWidget(login_link)
+        layout.addStretch(1)
+
+    def _emit_register(self) -> None:
+        self.registerRequested.emit(
+            self.username_input.text(), self.email_input.text(), self.password_input.text()
+        )
+
+
+class AdminPanel(QtWidgets.QMainWindow):
+    def __init__(self, admin: User) -> None:
+        super().__init__()
+        self.admin = admin
+        self.setWindowTitle("Admin Panel - Pending Users")
+        self.resize(500, 400)
+
+        central = QtWidgets.QWidget()
+        layout = QtWidgets.QVBoxLayout(central)
+
+        self.pending_list = QtWidgets.QListWidget()
+
+        button_layout = QtWidgets.QHBoxLayout()
+        self.approve_button = QtWidgets.QPushButton("Approve")
+        self.reject_button = QtWidgets.QPushButton("Reject")
+        self.refresh_button = QtWidgets.QPushButton("Refresh")
+
+        self.approve_button.clicked.connect(self.approve_selected)
+        self.reject_button.clicked.connect(self.reject_selected)
+        self.refresh_button.clicked.connect(self.refresh_pending)
+
+        button_layout.addWidget(self.approve_button)
+        button_layout.addWidget(self.reject_button)
+        button_layout.addStretch(1)
+        button_layout.addWidget(self.refresh_button)
+
+        layout.addWidget(QtWidgets.QLabel(f"Logged in as admin: {admin.username}"))
+        layout.addWidget(self.pending_list)
+        layout.addLayout(button_layout)
+
+        self.setCentralWidget(central)
+
+        self.refresh_pending()
+
+    def refresh_pending(self) -> None:
+        self.pending_list.clear()
+        for user in list_pending_users():
+            item = QtWidgets.QListWidgetItem(f"{user.username} ({user.email}) - {user.status}")
+            item.setData(QtCore.Qt.UserRole, user.username)
+            self.pending_list.addItem(item)
+
+    def _selected_username(self) -> str | None:
+        item = self.pending_list.currentItem()
+        if item:
+            return item.data(QtCore.Qt.UserRole)
+        QtWidgets.QMessageBox.warning(self, "Selection Required", "Select a user first.")
+        return None
+
+    def approve_selected(self) -> None:
+        username = self._selected_username()
+        if not username:
+            return
+        approve_user(username)
+        QtWidgets.QMessageBox.information(self, "User Approved", f"{username} is now approved.")
+        self.refresh_pending()
+
+    def reject_selected(self) -> None:
+        username = self._selected_username()
+        if not username:
+            return
+        reject_user(username)
+        QtWidgets.QMessageBox.information(self, "User Rejected", f"{username} has been rejected.")
+        self.refresh_pending()
+
+
+class AuthWindow(QtWidgets.QMainWindow):
+    def __init__(self) -> None:
+        super().__init__()
+        self.setWindowTitle("Industrial Data System - Login")
+        self.resize(360, 320)
+
+        central = QtWidgets.QWidget()
+        layout = QtWidgets.QVBoxLayout(central)
+
+        self.stack = QtWidgets.QStackedWidget()
+        self.login_widget = LoginWidget()
+        self.register_widget = RegisterWidget()
+
+        self.login_widget.loginRequested.connect(self.handle_login)
+        self.login_widget.showRegister.connect(self.show_register)
+
+        self.register_widget.registerRequested.connect(self.handle_registration)
+        self.register_widget.showLogin.connect(self.show_login)
+
+        self.stack.addWidget(self.login_widget)
+        self.stack.addWidget(self.register_widget)
+
+        layout.addWidget(self.stack)
+        self.setCentralWidget(central)
+
+        self.main_window: MainWindow | None = None
+        self.admin_panel: AdminPanel | None = None
+
+    def show_register(self) -> None:
+        self.stack.setCurrentWidget(self.register_widget)
+
+    def show_login(self) -> None:
+        self.stack.setCurrentWidget(self.login_widget)
+
+    def handle_login(self, username: str, password: str) -> None:
+        try:
+            user = authenticate_user(username, password)
+        except LoginError as exc:
+            QtWidgets.QMessageBox.warning(self, "Login Failed", str(exc))
+            return
+
+        if user.role == "admin":
+            self.admin_panel = AdminPanel(user)
+            self.admin_panel.show()
+            QtWidgets.QMessageBox.information(
+                self, "Admin Login", "Admin panel opened in a new window."
+            )
+            self.close()
+            return
+
+        if user.status != "approved":
+            QtWidgets.QMessageBox.information(
+                self,
+                "Awaiting Approval",
+                "Your registration is pending admin approval.",
+            )
+            return
+
+        self.main_window = MainWindow(user)
+        self.main_window.show()
+        self.close()
+
+    def handle_registration(self, username: str, email: str, password: str) -> None:
+        try:
+            register_user(username, email, password)
+        except RegistrationError as exc:
+            QtWidgets.QMessageBox.warning(self, "Registration Failed", str(exc))
+            return
+
+        QtWidgets.QMessageBox.information(
+            self,
+            "Registration Submitted",
+            "Registration received. Please wait for admin approval before logging in.",
+        )
+        self.show_login()
+
+
+def main() -> None:
+    app = QtWidgets.QApplication(sys.argv)
+    window = AuthWindow()
+    window.show()
+    sys.exit(app.exec_())
+
+
+if __name__ == "__main__":
+    main()

--- a/onedrive_auth.py
+++ b/onedrive_auth.py
@@ -1,0 +1,45 @@
+"""Helpers for acquiring an access token for Microsoft Graph."""
+from __future__ import annotations
+
+import os
+
+import msal
+from dotenv import load_dotenv
+
+load_dotenv()
+
+CLIENT_ID = os.getenv("CLIENT_ID")
+TENANT_ID = os.getenv("TENANT_ID")
+CLIENT_SECRET = os.getenv("CLIENT_SECRET")
+
+AUTHORITY = f"https://login.microsoftonline.com/{TENANT_ID}" if TENANT_ID else None
+SCOPE = ["https://graph.microsoft.com/.default"]
+
+
+def _validate_settings() -> None:
+    missing = [
+        name
+        for name, value in {
+            "CLIENT_ID": CLIENT_ID,
+            "TENANT_ID": TENANT_ID,
+            "CLIENT_SECRET": CLIENT_SECRET,
+        }.items()
+        if not value
+    ]
+    if missing:
+        raise RuntimeError(f"Missing OneDrive configuration for: {', '.join(missing)}")
+
+
+def get_access_token() -> str:
+    _validate_settings()
+    app = msal.ConfidentialClientApplication(
+        CLIENT_ID,
+        authority=AUTHORITY,
+        client_credential=CLIENT_SECRET,
+    )
+    result = app.acquire_token_silent(SCOPE, account=None)
+    if not result:
+        result = app.acquire_token_for_client(scopes=SCOPE)
+    if "access_token" in result:
+        return result["access_token"]
+    raise RuntimeError(result.get("error_description"))

--- a/onedrive_upload.py
+++ b/onedrive_upload.py
@@ -1,0 +1,33 @@
+"""Upload CSV files to OneDrive using Microsoft Graph."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Union
+
+import requests
+
+from onedrive_auth import get_access_token
+
+APP_FOLDER = os.getenv("ONEDRIVE_APP_FOLDER", "IndustrialDataSystem")
+
+
+def _build_upload_url(filename: str, username: str) -> str:
+    safe_username = username.replace("/", "_")
+    return (
+        "https://graph.microsoft.com/v1.0/me/drive/root:/"
+        f"Apps/{APP_FOLDER}/Users/{safe_username}/{filename}:/content"
+    )
+
+
+def upload_file_to_onedrive(local_path: Union[str, Path], username: str) -> None:
+    path = Path(local_path)
+    if not path.exists():
+        raise FileNotFoundError(path)
+    token = get_access_token()
+    upload_url = _build_upload_url(path.name, username)
+    headers = {"Authorization": f"Bearer {token}", "Content-Type": "text/csv"}
+    with path.open("rb") as handle:
+        response = requests.put(upload_url, headers=headers, data=handle)
+    if response.status_code not in (200, 201):
+        raise RuntimeError(f"Upload failed: {response.status_code} {response.text}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,7 @@
 bcrypt==4.1.2
-cryptography==41.0.7
 msal==1.26.0
-openpyxl==3.1.2
 pandas==2.1.4
-Pillow==10.1.0
+PyQt5==5.15.10
 python-dotenv==1.0.0
 requests==2.31.0
-
-# Tkinter ships with the standard library on most platforms.
+pyinstaller==5.13.2


### PR DESCRIPTION
## Summary
- implement a PyQt5 desktop client with login/registration workflow and admin approval gate
- add SQLite-backed authentication helpers with bcrypt hashing and OneDrive upload utilities
- document environment configuration, packaging steps, and required dependencies

## Testing
- python -m compileall .


------
https://chatgpt.com/codex/tasks/task_e_68e6075a9f4483228cb870a3ae1466f2