### PR TITLE
Refactor authentication to use PostgreSQL and reset flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,25 @@
 # Rename this file to .env and populate with your credentials.
+# Database connection (PostgreSQL URL format recommended).
+DATABASE_URL=postgresql://user:password@localhost:5432/industrial_data
+
 # Optional: bootstrap an initial admin user.
 ADMIN_USERNAME=admin
 ADMIN_PASSWORD=change-me
 ADMIN_EMAIL=admin@example.com
+
+# Authentication & security settings.
+IDS_JWT_SECRET=change-this-secret
+IDS_SESSION_TTL_MINUTES=120
+IDS_RESET_TOKEN_TTL_MINUTES=30
+
+# Optional SMTP configuration for password reset emails.
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_USERNAME=smtp-user
+SMTP_PASSWORD=smtp-password
+SMTP_USE_TLS=true
+MAIL_DEFAULT_SENDER=no-reply@example.com
+
 # Cloudinary configuration for uploads.
 CLOUDINARY_CLOUD_NAME=your-cloud-name
 CLOUDINARY_API_KEY=your-api-key

--- a/README.md
+++ b/README.md
@@ -1,102 +1,129 @@
 # Industrial Data System Desktop Application
 
-A PyQt5 desktop application featuring admin-approved authentication, CSV previewing, and uploads to Cloudinary.
+A PyQt5 desktop application featuring admin-approved authentication, CSV previewing, and uploads to Cloudinary. The project now uses PostgreSQL (or any SQLAlchemy-compatible RDBMS) with Alembic migrations, secure JWT-backed sessions, and a complete password reset workflow.
 
 ## Features
 
-- Login and registration workflow with admin approval.
+- Login, registration, and admin approval workflow backed by SQLAlchemy.
+- JWT-based user sessions with explicit logout controls for end users and administrators.
+- "Forgot password" flow with email dispatch (via SMTP) or on-screen reset tokens for development.
 - Admin panel for reviewing, approving, or rejecting pending accounts.
 - CSV viewer with upload button and drag-and-drop support.
 - Cloudinary integration for storing uploads in user-specific folders.
-- Password hashing using bcrypt and environment-based configuration for secrets.
+- Environment-based configuration using `.env` for database, JWT, SMTP, and Cloudinary credentials.
 
 ## Project Structure
 
 ```
 project/
+├── alembic.ini
 ├── auth.py
+├── cloudinary_upload.py
 ├── database.py
 ├── main.py
-├── cloudinary_upload.py
+├── migrations/
+│   ├── env.py
+│   ├── README
+│   └── versions/
+│       └── 20240401_0001_initial.py
 ├── requirements.txt
 ├── README.md
-└── .env               # provide your own values before running
+└── .env.example        # copy to .env and fill in secrets
 ```
 
 ## Prerequisites
 
 - Python 3.10+
+- A PostgreSQL instance (local Docker container, managed service, etc.). SQLAlchemy URLs for other engines such as MySQL are supported, but PostgreSQL is recommended.
 - Cloudinary account (free tier is sufficient) with API credentials.
+- Optional: SMTP account for sending password reset emails.
 
-## Installation
+## Installation & Configuration
 
-1. (Optional) create and activate a virtual environment.
-2. Install dependencies:
+1. **Create and activate a virtual environment (optional but recommended).**
 
+2. **Install dependencies.**
    ```bash
    pip install -r requirements.txt
    ```
 
-3. Copy `.env.example` and populate the values:
-
+3. **Copy the example environment file and populate values.**
    ```bash
    cp .env.example .env
-   # Edit .env and fill in the Cloudinary credentials.
    ```
+   Edit `.env` and provide at minimum:
+   - `DATABASE_URL` – e.g. `postgresql://user:password@localhost:5432/industrial_data`
+   - `IDS_JWT_SECRET` – a long random secret used for signing JWT session tokens.
+   - `CLOUDINARY_CLOUD_NAME`, `CLOUDINARY_API_KEY`, `CLOUDINARY_API_SECRET`
 
-   Set the `CLOUDINARY_CLOUD_NAME`, `CLOUDINARY_API_KEY`, and `CLOUDINARY_API_SECRET` from your Cloudinary dashboard. Optionally set `ADMIN_USERNAME`, `ADMIN_PASSWORD`, and `ADMIN_EMAIL` to bootstrap an approved admin on startup.
+   Optional but recommended entries:
+   - `ADMIN_USERNAME`, `ADMIN_PASSWORD`, `ADMIN_EMAIL` – bootstrap an approved admin on first launch.
+   - `SMTP_*` values (host, port, username, password, TLS flag, and `MAIL_DEFAULT_SENDER`) to enable email-based password reset delivery.
+   - `IDS_SESSION_TTL_MINUTES` and `IDS_RESET_TOKEN_TTL_MINUTES` to adjust session/token lifetimes.
 
-4. Export `IDS_DB_PATH` if you want to override the default SQLite database location (defaults to `app.db`).
-
-## Usage
-
-1. (Optional) export explicit admin credentials. When omitted, a default admin
-   account (`admin` / `admin123`) is created automatically on first launch to
-   allow registrations to be approved.
-
+4. **Create the application database.** For PostgreSQL, from a shell with appropriate credentials:
    ```bash
-   export ADMIN_USERNAME="your-admin"
-   export ADMIN_PASSWORD="change-me"
-   export ADMIN_EMAIL="admin@example.com"  # optional override
+   createdb industrial_data
    ```
+   (Adjust the database name or create it via your hosting provider’s console as needed.)
 
-2. Run the application:
+5. **Run database migrations.**
+   ```bash
+   alembic upgrade head
+   ```
+   This creates the `users` and `password_reset_tokens` tables using the connection string specified in `DATABASE_URL`.
 
+6. **Run the application.**
    ```bash
    python main.py
    ```
 
+## Usage
+
+1. Optionally export explicit admin credentials if you did not set them in `.env`:
+   ```bash
+   export ADMIN_USERNAME="your-admin"
+   export ADMIN_PASSWORD="change-me"
+   export ADMIN_EMAIL="admin@example.com"
+   ```
+2. Launch the app with `python main.py`.
 3. Register a new user. The registration will be stored as `pending` until an admin approves it.
-4. Log in as an admin and use the admin panel to approve or reject users.
+4. Log in as an admin and use the admin panel to approve or reject users. Admins can log out directly from the panel.
 5. Once approved, a user can log in to access the main interface:
-   - **Upload CSV** button in the top-left corner opens a file dialog.
-   - **Drag-and-drop box** in the bottom-right corner accepts `.csv` files.
-   - The center table displays the CSV contents.
-   - After previewing the CSV, confirm the Cloudinary upload prompt to store the file in your configured account.
+   - **Upload CSV** button opens a file dialog.
+   - **Drag-and-drop box** accepts `.csv` files.
+   - The table displays the CSV contents.
+   - After previewing the CSV, confirm the Cloudinary upload prompt to store the file.
+6. **Logout** – The main window includes a logout button which revokes the in-memory JWT and returns to the login screen. Closing the window also logs the user out.
+
+## Password Reset Flow
+
+1. Click **Forgot Password?** on the login screen and submit the email associated with your account.
+2. If SMTP is configured, the app sends an email containing a one-time token. When email is not configured (development mode), the token is displayed in-app so you can copy it manually.
+3. Use the **Reset Password** view to paste the token and choose a new password.
+4. After a successful reset, return to the login screen and authenticate with the updated credentials.
 
 ## Cloudinary Setup
 
 1. Create a free account at [Cloudinary](https://cloudinary.com/).
 2. From the dashboard, copy your **Cloud name**, **API Key**, and **API Secret**.
-3. Add them to your `.env` file:
-
-   ```ini
-   CLOUDINARY_CLOUD_NAME=your_cloud_name
-   CLOUDINARY_API_KEY=your_key
-   CLOUDINARY_API_SECRET=your_secret
-   ```
-
+3. Add them to your `.env` file and restart the application if it was running.
 4. Run the application and confirm the Cloudinary upload prompt after selecting or dropping a file.
 
-## Admin workflow
+## Database Migrations
 
-- The admin panel opens immediately after a successful admin login. Every
-  registration that has not yet been reviewed appears in the list with status
-  `pending`.
-- Select a user and click **Approve** to grant access or **Reject** to deny the
-  request. Use **Refresh** to retrieve the latest registrations from the
-  database.
-- End users can log in only after their account has been approved by an admin.
+- Generate a new migration when models change:
+  ```bash
+  alembic revision --autogenerate -m "describe change"
+  ```
+- Apply migrations:
+  ```bash
+  alembic upgrade head
+  ```
+- Downgrade if required:
+  ```bash
+  alembic downgrade -1
+  ```
 
 ## Packaging
 
@@ -110,11 +137,14 @@ The resulting binary will be placed in the `dist/` directory.
 
 ## Troubleshooting
 
-- **Missing configuration** – ensure `.env` is present with valid Cloudinary credentials before running the app.
+- **Missing configuration** – ensure `.env` is present with valid database, JWT secret, and Cloudinary credentials before running the app.
+- **Database connectivity issues** – confirm that the database server is reachable from your machine and that `DATABASE_URL` is correct.
 - **Cloudinary upload failures** – verify that your API credentials are correct and the account allows the selected resource type.
+- **Password reset email not received** – double-check SMTP configuration. Tokens always display in-app when email is disabled to support local testing.
 
 ## Security Notes
 
 - Secrets should never be committed to source control. Use a local `.env` or environment variables.
-- Passwords are hashed using bcrypt before being stored in SQLite.
-- Delete or protect the SQLite database (`app.db`) if sensitive data is stored locally.
+- Passwords are hashed using bcrypt before being stored in the database.
+- JWT session tokens are signed using `IDS_JWT_SECRET`; rotate this secret regularly and keep it private.
+- PostgreSQL (or your chosen backend) should enforce SSL/TLS in production and restrict inbound connections.

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,35 @@
+[alembic]
+script_location = migrations
+sqlalchemy.url = ${DATABASE_URL}
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers = console
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(asctime)s %(levelname)-5.5s [%(name)s] %(message)s

--- a/auth.py
+++ b/auth.py
@@ -1,19 +1,31 @@
 """Authentication helpers for the Industrial Data System application."""
 from __future__ import annotations
 
+import hashlib
 import os
+import secrets
+import smtplib
 import warnings
 from dataclasses import dataclass
-from typing import List
+from datetime import datetime, timedelta, timezone
+from email.message import EmailMessage
+from typing import List, Optional
 
 import bcrypt
+import jwt
 
 from database import (
+    UserModel,
     add_user,
+    create_reset_token,
     ensure_admin_user,
     get_pending_users,
+    get_reset_token_by_hash,
+    get_user_by_email,
     get_user_by_username,
     has_admin_user,
+    mark_token_used,
+    update_user_password,
     update_user_status,
 )
 
@@ -30,8 +42,17 @@ class LoginError(AuthError):
     """Raised when login fails."""
 
 
+class SessionError(AuthError):
+    """Raised when a JWT session token cannot be validated."""
+
+
+class PasswordResetError(AuthError):
+    """Raised for password reset workflow issues."""
+
+
 @dataclass
 class User:
+    id: int
     username: str
     email: str
     role: str
@@ -62,6 +83,8 @@ def register_user(username: str, email: str, password: str) -> None:
         raise RegistrationError("Email cannot be empty")
     if get_user_by_username(username):
         raise RegistrationError("Username already exists")
+    if get_user_by_email(email):
+        raise RegistrationError("Email already registered")
     password_hash = hash_password(password)
     add_user(username=username, email=email, password_hash=password_hash)
 
@@ -71,19 +94,14 @@ def authenticate_user(username: str, password: str) -> User:
     record = get_user_by_username(username)
     if not record:
         raise LoginError("Invalid username or password")
-    if not verify_password(password, record["password_hash"]):
+    if not verify_password(password, record.password_hash):
         raise LoginError("Invalid username or password")
-    return User(
-        username=record["username"],
-        email=record["email"],
-        role=record["role"],
-        status=record["status"],
-    )
+    return _user_from_model(record)
 
 
 def list_pending_users() -> List[User]:
     return [
-        User(username=row["username"], email=row["email"], role=row["role"], status=row["status"])
+        _user_from_model(row)
         for row in get_pending_users()
     ]
 
@@ -94,6 +112,144 @@ def approve_user(username: str) -> None:
 
 def reject_user(username: str) -> None:
     update_user_status(normalize_username(username), "rejected")
+
+
+def create_session_token(user: User) -> str:
+    """Generate a JWT for the authenticated user."""
+
+    secret = os.getenv("IDS_JWT_SECRET")
+    if not secret:
+        raise SessionError("Missing IDS_JWT_SECRET environment variable.")
+
+    ttl_minutes = int(os.getenv("IDS_SESSION_TTL_MINUTES", "60"))
+    payload = {
+        "sub": user.username,
+        "uid": user.id,
+        "role": user.role,
+        "email": user.email,
+        "exp": datetime.now(timezone.utc) + timedelta(minutes=ttl_minutes),
+        "iat": datetime.now(timezone.utc),
+    }
+    algorithm = os.getenv("IDS_JWT_ALGORITHM", "HS256")
+    return jwt.encode(payload, secret, algorithm=algorithm)
+
+
+def validate_session_token(token: str) -> dict:
+    """Validate a JWT session token and return its payload."""
+
+    secret = os.getenv("IDS_JWT_SECRET")
+    if not secret:
+        raise SessionError("Missing IDS_JWT_SECRET environment variable.")
+
+    algorithm = os.getenv("IDS_JWT_ALGORITHM", "HS256")
+    try:
+        return jwt.decode(token, secret, algorithms=[algorithm])
+    except jwt.ExpiredSignatureError as exc:  # pragma: no cover - environment dependent
+        raise SessionError("Session token has expired. Please log in again.") from exc
+    except jwt.PyJWTError as exc:  # pragma: no cover - invalid token edge cases
+        raise SessionError("Invalid session token.") from exc
+
+
+def request_password_reset(email: str) -> Optional[str]:
+    """Create a password reset token and dispatch it via email.
+
+    Returns the raw token string when email delivery is not configured so that
+    developers can complete the flow manually. Otherwise returns ``None``.
+    """
+
+    email = email.strip().lower()
+    if not email:
+        raise PasswordResetError("Email address is required.")
+
+    user = get_user_by_email(email)
+    if not user:
+        # Intentionally do not disclose that the account is missing.
+        return None
+
+    raw_token = secrets.token_urlsafe(32)
+    token_hash = _hash_reset_token(raw_token)
+    ttl_minutes = int(os.getenv("IDS_RESET_TOKEN_TTL_MINUTES", "30"))
+    create_reset_token(user, token_hash, ttl_minutes)
+
+    email_sent = _send_password_reset_email(email, raw_token)
+    return None if email_sent else raw_token
+
+
+def reset_password(token: str, new_password: str) -> None:
+    """Reset a user's password if the provided token is valid."""
+
+    if not token:
+        raise PasswordResetError("A reset token is required.")
+    if not new_password:
+        raise PasswordResetError("New password must not be empty.")
+
+    token_hash = _hash_reset_token(token)
+    reset_record = get_reset_token_by_hash(token_hash)
+    if not reset_record or reset_record.used:
+        raise PasswordResetError("Invalid or already used password reset token.")
+
+    if reset_record.expires_at < datetime.now(timezone.utc):
+        raise PasswordResetError("Password reset token has expired.")
+
+    user = reset_record.user
+    password_hash = hash_password(new_password)
+    update_user_password(user, password_hash)
+    mark_token_used(reset_record.id)
+
+
+def _hash_reset_token(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def _send_password_reset_email(recipient: str, token: str) -> bool:
+    host = os.getenv("SMTP_HOST")
+    if not host:
+        return False
+
+    port = int(os.getenv("SMTP_PORT", "587"))
+    username = os.getenv("SMTP_USERNAME")
+    password = os.getenv("SMTP_PASSWORD")
+    use_tls = os.getenv("SMTP_USE_TLS", "true").lower() == "true"
+    sender = os.getenv("MAIL_DEFAULT_SENDER", "no-reply@example.com")
+
+    message = EmailMessage()
+    message["Subject"] = "Industrial Data System Password Reset"
+    message["From"] = sender
+    message["To"] = recipient
+    message.set_content(
+        (
+            "You requested a password reset for the Industrial Data System application.\n\n"
+            f"Use the following token within the next {os.getenv('IDS_RESET_TOKEN_TTL_MINUTES', '30')} minutes:\n"
+            f"{token}\n\n"
+            "If you did not request this change you can ignore this email."
+        )
+    )
+
+    try:
+        if use_tls:
+            with smtplib.SMTP(host, port) as smtp:
+                smtp.starttls()
+                if username and password:
+                    smtp.login(username, password)
+                smtp.send_message(message)
+        else:
+            with smtplib.SMTP(host, port) as smtp:
+                if username and password:
+                    smtp.login(username, password)
+                smtp.send_message(message)
+    except Exception:  # pragma: no cover - network dependent
+        return False
+    return True
+
+
+def _user_from_model(model: UserModel) -> User:
+    return User(
+        id=model.id,
+        username=model.username,
+        email=model.email,
+        role=model.role,
+        status=model.status,
+    )
 
 
 def bootstrap_default_admin() -> None:

--- a/migrations/README
+++ b/migrations/README
@@ -1,0 +1,8 @@
+This directory contains Alembic migration scripts for the Industrial Data System
+application. To generate a new revision run::
+
+    alembic revision --autogenerate -m "descriptive message"
+
+Apply the latest migrations with::
+
+    alembic upgrade head

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import os
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+from dotenv import load_dotenv
+
+from database import Base
+
+load_dotenv()
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+def get_url() -> str:
+    url = os.getenv("DATABASE_URL")
+    if not url:
+        raise RuntimeError("DATABASE_URL environment variable is required for migrations.")
+    return url
+
+
+def run_migrations_offline() -> None:
+    url = get_url()
+    context.configure(
+        url=url,
+        target_metadata=Base.metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    configuration = config.get_section(config.config_ini_section, {})
+    configuration["sqlalchemy.url"] = get_url()
+
+    connectable = engine_from_config(
+        configuration,
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=Base.metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/migrations/versions/20240401_0001_initial.py
+++ b/migrations/versions/20240401_0001_initial.py
@@ -1,0 +1,62 @@
+"""Initial database schema.
+
+Revision ID: 20240401_0001
+Revises: 
+Create Date: 2024-04-01 00:00:00.000000
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "20240401_0001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "users",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("username", sa.String(length=150), nullable=False, unique=True, index=True),
+        sa.Column("email", sa.String(length=255), nullable=False, unique=True, index=True),
+        sa.Column("password_hash", sa.String(length=255), nullable=False),
+        sa.Column("role", sa.String(length=50), nullable=False, server_default="user"),
+        sa.Column("status", sa.String(length=50), nullable=False, server_default="pending"),
+    )
+    op.create_index("ix_users_username", "users", ["username"], unique=True)
+    op.create_index("ix_users_email", "users", ["email"], unique=True)
+
+    op.create_table(
+        "password_reset_tokens",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("user_id", sa.Integer(), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("token_hash", sa.String(length=128), nullable=False, unique=True, index=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column(
+            "used",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.sql.expression.false(),
+        ),
+    )
+    op.create_index("ix_password_reset_tokens_token_hash", "password_reset_tokens", ["token_hash"], unique=True)
+    op.create_index("ix_password_reset_tokens_user_id", "password_reset_tokens", ["user_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_password_reset_tokens_user_id", table_name="password_reset_tokens")
+    op.drop_index("ix_password_reset_tokens_token_hash", table_name="password_reset_tokens")
+    op.drop_table("password_reset_tokens")
+    op.drop_index("ix_users_email", table_name="users")
+    op.drop_index("ix_users_username", table_name="users")
+    op.drop_table("users")

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,7 @@ python-dotenv==1.0.1
 requests==2.31.0
 pyinstaller==5.13.2
 cloudinary==1.36.0
+SQLAlchemy==2.0.29
+alembic==1.13.1
+psycopg2-binary==2.9.9
+PyJWT==2.8.0


### PR DESCRIPTION
## Summary
- migrate database utilities to SQLAlchemy with PostgreSQL support and Alembic migrations
- add JWT-backed sessions, logout, and password reset screens to the desktop client
- document new environment configuration for database, JWT, SMTP, and migrations

## Testing
- python -m compileall auth.py database.py main.py migrations

------
https://chatgpt.com/codex/tasks/task_e_68e6354414e48322b31b5d623416e757