### PR TITLE
Replace Flask web app with PyQt5 desktop client

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-flask==3.0.3
+PyQt5==5.15.10
 supabase==2.4.0
 cloudinary==1.36.0
 python-dotenv==1.0.1


### PR DESCRIPTION
## Summary
- replace the previous Flask server with a PyQt5 desktop application that handles authentication, file listing, uploads, and password reset flows
- add a reusable session manager for Supabase tokens and integrate Cloudinary uploads into the desktop workflow
- update dependencies to include PyQt5 and remove Flask from the requirements list

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68e65c500f6883228853ec6c7e158ea5