### PR TITLE
Fix Cloudinary upload for CSV files

### DIFF
--- a/app.py
+++ b/app.py
@@ -655,7 +655,12 @@ class IndustrialDataApp(QMainWindow):
         self.dashboard_page.display_csv_preview(headers, rows)
 
         try:
-            upload_result = cloudinary.uploader.upload(file_path)
+            upload_result = cloudinary.uploader.upload(
+                file_path,
+                resource_type="raw",
+                use_filename=True,
+                unique_filename=False,
+            )
         except Exception as exc:
             self._alert(f"Cloudinary upload failed: {exc}", QMessageBox.Critical)
             return


### PR DESCRIPTION
## Summary
- configure Cloudinary uploads for CSV files to use the raw resource type
- keep the original filename when uploading to ease identification

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68e6685ff9248322b2462f79afa922dd